### PR TITLE
LIBFCREPO-1302. Change PyYAML version from 5.4 to 6.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 stomp.py==4.1.21
 isodate==0.6.0
 requests==2.21.0
-PyYAML==5.4
+PyYAML==6.0.1


### PR DESCRIPTION
Updated the "requirements.txt" file to change the "PyYAML dependency version from "5.4" to "6.0.1".

This is necessary to build the "docker.lib.umd.edu/fcrepo-fixity" Docker image on Apple Silicon laptops.

Without this change, the following error occurs when building the Docker image:

```
$ docker build -t docker.lib.umd.edu/fcrepo-fixity umd-fcrepo-fixity

...

 => [2/5] WORKDIR /usr/src/app                                                                                                                    0.1s
 => [3/5] COPY requirements.txt ./                                                                                                                0.0s
 => ERROR [4/5] RUN pip install --no-cache-dir -r requirements.txt                                                                                4.4s
------
 > [4/5] RUN pip install --no-cache-dir -r requirements.txt:
#8 0.694 Collecting stomp.py==4.1.21 (from -r requirements.txt (line 1))

...

#8 4.177   AttributeError: cython_sources
#8 4.177   ----------------------------------------
#8 4.205 ERROR: Command "/usr/local/bin/python /usr/local/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpqjvi5qkz" failed with error code 1 in /tmp/pip-install-4dd708_c/PyYAML
#8 4.349 WARNING: You are using pip version 19.1.1, however version 21.3.1 is available.
#8 4.349 You should consider upgrading via the 'pip install --upgrade pip' command.
------
executor failed running [/bin/sh -c pip install --no-cache-dir -r requirements.txt]: exit code: 1
```

https://umd-dit.atlassian.net/browse/LIBFCREPO-1302